### PR TITLE
Use parameters to exclude arrays, dicts, and structs.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,13 +1,13 @@
 A Hypothesis Strategy for Generating Arbitrary DBus Signatures
 ==============================================================
 
-This package contains a Hypothesis strategy for generating dbus signatures.
-An informal specification of dbus signatures is available at:
+This package contains a Hypothesis strategy for generating DBus signatures.
+An informal specification of DBus signatures is available at:
 https://dbus.freedesktop.org/doc/dbus-specification.html.
 
 The strategy is intended to be both sound and complete. That is, it should
-never generate an invalid dbus signature and it should be capable, modulo
-size constraints, of generating any valid dbus signature.
+never generate an invalid DBus signature and it should be capable, modulo
+size constraints, of generating any valid DBus signature.
 
 Usage
 -----

--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ Make use of the strategy in your tests, e.g. ::
 
 Use the parameters to omit dicts ::
 
-    >>> strategy = dbus_signatures(blacklist="{")
+    >>> strategy = dbus_signatures(exclude_dicts=True)
     >>> strategy.example()
     '(gnggg)(n)(gn)(nnnnn)(nn)'
 

--- a/src/hs_dbus_signature/_version.py
+++ b/src/hs_dbus_signature/_version.py
@@ -8,5 +8,5 @@
 Version information.
 """
 
-__version__ = '0.04'
+__version__ = '0.05'
 __version_info__ = tuple(int(x) for x in __version__.split('.'))

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -17,8 +17,7 @@ from hs_dbus_signature import dbus_signatures
 
 from hs_dbus_signature._signature import _DBusSignatureStrategy
 
-_TYPE_CODES = _DBusSignatureStrategy.CODES
-_CODES = _TYPE_CODES + ['a', '{', '(']
+_CODES = _DBusSignatureStrategy.CODES
 _NUM_CODES = len(_CODES)
 
 @strategies.composite
@@ -57,6 +56,9 @@ def dbus_signature_strategy(draw):
        max_complete_types=max_complete_types,
        min_struct_len=min_struct_len,
        max_struct_len=max_struct_len,
+       exclude_arrays=draw(strategies.booleans()),
+       exclude_dicts=draw(strategies.booleans()),
+       exclude_structs=draw(strategies.booleans()),
        blacklist=blacklist
     )
 
@@ -93,7 +95,7 @@ class SignatureStrategyTestCase(unittest.TestCase):
                    max_codes=x,
                    min_complete_types=1,
                    max_complete_types=1,
-                   blacklist='{'
+                   exclude_dicts=True
              )
           )
        )
@@ -120,7 +122,7 @@ class SignatureStrategyTestCase(unittest.TestCase):
         """
         Verify correct behavior when blacklist contains all type codes.
         """
-        blacklist = ''.join(_TYPE_CODES)
+        blacklist = ''.join(_CODES)
         with self.assertRaises(errors.InvalidArgument):
             dbus_signatures(blacklist=blacklist)
 


### PR DESCRIPTION
Much better than using synecdochical characters in the blacklist.

Signed-off-by: mulhern <amulhern@redhat.com>